### PR TITLE
add -lpthread to the cc line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	cc -I/usr/local/include -L/usr/local/lib -Ofast -o nanopond nanopond.c -lSDL2
+	cc -I/usr/local/include -L/usr/local/lib -Ofast -o nanopond nanopond.c -lSDL2 -lpthread
 
 clean:
 	rm -rf *.o nanopond *.dSYM


### PR DESCRIPTION
Fixes undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'